### PR TITLE
inline functions to avoid duplicate symbols

### DIFF
--- a/src/cxxurl/Request.h
+++ b/src/cxxurl/Request.h
@@ -93,9 +93,9 @@ protected:
     CURL *m_Curl;
 
 protected:
-    static size_t writeContent(char *buffer, size_t size, size_t count, void *stream);
+    inline static size_t writeContent(char *buffer, size_t size, size_t count, void *stream);
 
-    static size_t writeHeader(char *buffer, size_t size, size_t count, void *stream);
+    inline static size_t writeHeader(char *buffer, size_t size, size_t count, void *stream);
 
 DEFINE_PROP_GETTER_SETTER(std::string, Url)
 

--- a/src/cxxurl/UrlEncoder.h
+++ b/src/cxxurl/UrlEncoder.h
@@ -18,8 +18,8 @@ class UrlEncoder {
         static inline unsigned char FromHex(unsigned char x);
 
     public:
-        static std::string encode(const std::string& str);
-        static std::string decode(const std::string& str);
+        static inline std::string encode(const std::string& str);
+        static inline std::string decode(const std::string& str);
 
 };
 


### PR DESCRIPTION
when cxxurl is used by multiple libs in the same build.